### PR TITLE
registry name got third level, but split_fqdn don't split good value for tld

### DIFF
--- a/extra/uwhoisd.ini
+++ b/extra/uwhoisd.ini
@@ -25,12 +25,6 @@ max_age=500
 ; particular zone, specify it in this section.
 [overrides]
 bz=whois.afilias-grs.info
-co.bz=%(bz)s
-com.bz=%(bz)s
-gov.bz=%(bz)s
-mil.bz=%(bz)s
-net.bz=%(bz)s
-org.bz=%(bz)s
 ; CentralNIC
 ae.org=whois.centralnic.com
 ar.com=%(ae.org)s
@@ -61,8 +55,8 @@ us.org=%(ae.org)s
 uy.com=%(ae.org)s
 za.com=%(ae.org)s
 ; CoDNS/EuroDNS
-co.nl=whois.eurodns.com
-co.no=%(co.nl)s
+nl=whois.eurodns.com
+no=%(nl)s
 
 ; This exists for registries who require a specific prefix added to the query
 ; when querying for a domain. Some registries, such as VeriSign, will include
@@ -92,12 +86,6 @@ net=%(com)s
 tv=%(com)s
 cc=%(com)s
 bz=Whois Server: (?P<server>[\-a-z0-9.]+)
-co.bz=%(bz)s
-com.bz=%(bz)s
-net.bz=%(bz)s
-org.bz=%(bz)s
-mil.bz=%(bz)s
-gov.bz=%(bz)s
 ws=Registrar Whois: (?P<server>[\-a-z0-9.]+)
 
 ;
@@ -133,3 +121,33 @@ args=(sys.stdout,)
 ; Fields are tab separated.
 format=%(asctime)s	%(levelname)s:%(name)s	%(message)s
 datefmt=
+
+[third_level_tld]
+; tld with third level as second level
+ae.org=1
+ar.com=1
+br.com=1
+cn.com=1
+com.de=1
+de.com=1
+eu.com=1
+gb.com=1
+gb.net=1
+gr.com=1
+hu.com=1
+hu.net=1
+jp.net=1
+jpn.co=1
+kr.com=1
+no.com=1
+qc.com=1
+ru.com=1
+sa.com=1
+se.com=1
+se.net=1
+uk.com=1
+uk.net=1
+us.com=1
+us.org=1
+uy.com=1
+za.com=1


### PR DESCRIPTION
the tld for 'blabla.truc.name' was truc.name so I fixed it.

But my fix is big. 

We can just give an exception to split_fqdn for .name, to send "name"
