### PR TITLE
Remove duplicate TLDs

### DIFF
--- a/extra/conf.d/overrides.ini
+++ b/extra/conf.d/overrides.ini
@@ -47,8 +47,6 @@ co.no=%(co.nl)s
 ; Other SLDs
 ac.uk=whois.ja.net
 gov.uk=%(ac.uk)s
-fed.us=%(gov)s
-co.za=whois.co.za
 
 ; Guesswork
 priv.at=whois.nic.priv.at
@@ -58,8 +56,6 @@ co.ca=whois.co.ca
 ;edu.cn=whois.edu.cn
 fj=whois.usp.ac.fj
 ga=whois.dot.ga
-hm=whois.registry.hm
-int=whois.iana.org
 eu.org=whois.eu.org
 co.pl=whois.co.pl
 edu.ru=whois.informika.ru


### PR DESCRIPTION
Those 4 TLDs are re-defined further down in the file, python3 fails on that.