### PR TITLE
Switch to Google-style docs and implement hash in the token bucket

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for testing.
-"""
+"""Utility functions for testing."""
 
 from os import path
 
@@ -11,9 +9,7 @@ HERE = path.dirname(__file__)
 
 
 class Clock:
-    """
-    A fake clock.
-    """
+    """A fake clock."""
 
     def __init__(self, initial: int = 0):
         super().__init__()


### PR DESCRIPTION
## Summary by Sourcery

Adopt Google-style docstrings and typing for rate limiting utilities while making token bucket instances hashable.

Enhancements:
- Convert TokenBucket and Clock docstrings to Google-style format and add type hints to key methods.
- Implement __hash__ on TokenBucket and mark it as totally ordered via functools.total_ordering for improved comparability and usage in hashed collections.